### PR TITLE
Force variable "fields" in testFieldWithComment2 to be Deterministic

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -195,6 +195,12 @@ public class WireMarshaller<T> {
         BytesComment bytes = out.bytesComment();
         bytes.indent(+1);
         try {
+            Arrays.sort(fields, new Comparator<FieldAccess>() {
+                @Override
+                public int compare(FieldAccess o1, FieldAccess o2) {
+                    return o1.toString().compareTo(o2.toString());
+                }
+            });
             for (@NotNull FieldAccess field : fields)
                 field.write(t, out);
         } catch (IllegalAccessException e) {


### PR DESCRIPTION
The flaky test that I am going to fix lies in the repo [Chronicle-Wire](https://github.com/xiedaxia1hao/Chronicle-Wire).

The test name is net.openhft.chronicle.wire.YamlWireTest.testFieldWithComment2 (packageName.className.methodName). This test compares checks the toString() method of the FieldWithComment2 with two fields.

The FieldWithComment2 class:
```java
static class FieldWithComment2 extends SelfDescribingMarshallable {
    @Comment("a comment where the value=%s")
    String field;
    String field2;
}
```
The expected value of testFieldWithComment2 is:
```
!net.openhft.chronicle.wire.YamlWireTest$FieldWithComment2 {
  field: hello world, 		# a comment where the value=hello world
  field2: !!null ""
}
```
However, while we use the NonDex to run this test, the returning result shows:
```
!net.openhft.chronicle.wire.YamlWireTest$FieldWithComment2 {
  field2: !!null ""
  field: hello world, 		# a comment where the value=hello world
}
```
We can tell that the relative print order of field and field2 changed. The corresponding code snippet:
```java
for (@NotNull FieldAccess field : fields)
  field.write(t, out);
```
After tracing the call stack of this test, we find the reason behind it is that the array fields is mapped from the `map.values()`, whose order is not deterministic. Thus, to fix this problem, we need to sort the fields before we write the field value into our final string.

Below is the revised code:
```java
Arrays.sort(fields, new Comparator<FieldAccess>() {
    @Override
    public int compare(FieldAccess o1, FieldAccess o2) {
        return o1.toString().compareTo(o2.toString());
    }
});
for (@NotNull FieldAccess field : fields)
    field.write(t, out);
```
In this way, we will always sort the fields array based on their inherent string values, which ensures the order of our fields in the printed string will always remain the same.

This PR proposes this approach to sort the fields before iterating the fields, thus making it deterministic.